### PR TITLE
Front page content graph and access control fixes

### DIFF
--- a/webapp/courses/views.py
+++ b/webapp/courses/views.py
@@ -98,9 +98,9 @@ def course(request, course_slug, instance_slug):
     context["instance"] = instance_obj
 
     if is_course_staff(request.user, instance_obj):
-        contents = instance_obj.contents.all().order_by('ordinal_number')
+        contents = instance_obj.contents.filter(ordinal_number__gt=0).order_by('ordinal_number')
     else:
-        contents = instance_obj.contents.filter(visible=True).order_by('ordinal_number')
+        contents = instance_obj.contents.filter(ordinal_number__gt=0, visible=True).order_by('ordinal_number')
     
     if len(contents) > 0:
         tree = []


### PR DESCRIPTION
Fixed superuser not being able to see everything in some selectors
(course in coursinstance, courseinstace in file/image/videolink)

Fixed file/image uploader being changed on edit

Front page of a course instance is now added to the content graph
with ordinal number 0; ordinal 0 is not shown in the course index
listing.